### PR TITLE
Fix typo in AuthController comment

### DIFF
--- a/src/main/java/com/crm/crm_backend/controller/AuthController.java
+++ b/src/main/java/com/crm/crm_backend/controller/AuthController.java
@@ -94,7 +94,7 @@ public class AuthController {
         return ResponseEntity.ok(usuario);
     }
 
-    // actualizar contraseña del usuario logeado
+    // actualizar contraseña del usuario logueado
     @PutMapping("/me/password")
     public ResponseEntity<?> updatePassword(@RequestBody UpdatePasswordDTO dto,
             @AuthenticationPrincipal UserDetails userDetails) {


### PR DESCRIPTION
## Summary
- correct spelling of 'logueado' in password update comment

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6843928639b483298de4ec623cddd8e5